### PR TITLE
updating the key for test event

### DIFF
--- a/doc-source/tutorials-importing-data-lambda-function-import-job.md
+++ b/doc-source/tutorials-importing-data-lambda-function-import-job.md
@@ -164,7 +164,7 @@ After you create the function, you should test it to make sure that it's set up 
              "arn": "arn:aws:s3:::bucket-name"
            },
            "object": {
-             "key": "processed/testfile/testfile__part1_processed.csv"
+             "key": "processed/testfile/testfile__part1__of1_processed.csv"
            }
          }
        }


### PR DESCRIPTION
The key for processed file is updated to 'processed/testfile/testfile__part1__of1_processed.csv'

*Issue #, if available:*

*Description of changes:*
After processing, the file name generated by lambda function is 'processed/testfile/testfile__part1__of1_processed.csv', but not '"processed/testfile/testfile__part1_processed.csv"'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
