### PR TITLE
fix: Relative link for IAM policies and permissions documentation

### DIFF
--- a/doc-source/sms-voice-v2-event-destinations-sns.md
+++ b/doc-source/sms-voice-v2-event-destinations-sns.md
@@ -30,7 +30,7 @@ Use the following example to create a policy for sending events to an Amazon SNS
 }
 ```
 
-For more information about IAM policies, see [Policies and permissions in IAM](IAM/latest/UserGuide/access_policies.html) in the *IAM User Guide*\.
+For more information about IAM policies, see [Policies and permissions in IAM](/IAM/latest/UserGuide/access_policies.html) in the *IAM User Guide*\.
 
 ### Creating the event destination<a name="sms-voice-v2-event-destinations-sns-creating-cli"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The link for the IAM policies and permissions documentation was not pointing to the correct location. fixing the relative link to ensure that the documentation can be accessed correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
